### PR TITLE
DECT phone compatibility list v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -703,7 +703,7 @@ These people have contributed to improve this list for everyone (in no particula
 [28]:https://itunes.apple.com/us/app/30c3-fahrplan-30c3-event-organizer/id764609606?mt=8
 [29]:http://en.wikipedia.org/wiki/Knife_legislation#Germany
 [30]:https://rad1o.badge.events.ccc.de/ "Rad1o Badge, CCCamp 2015"
-[31]:https://www.eventphone.de/wiki/index.php/DECT_Phone_Compatibility_List "Eventphone DECT handset compatibility list"
+[31]:https://eventphone.de/doku/dect_phone_compatibility_list_v2:start "Eventphone DECT handset compatibility list v2"
 [32]:https://www.youtube.com/watch?v=J0MUEqzWve8 "YouTube: B.O.O.K."
 [33]:https://www.cryptoparty.in/location "List of international CryptoParty events"
 [34]:http://www.sperr-notruf.de/


### PR DESCRIPTION
Changed the link of the Eventphone DECT compatibility list to the new version (due to the changed PBX/DECT system in 2018).